### PR TITLE
fix: upstream github graph changes

### DIFF
--- a/src/routes/[user]/[year]/+server.ts
+++ b/src/routes/[user]/[year]/+server.ts
@@ -41,10 +41,8 @@ function parseContributions(html: string) {
 			if (data.length > 1) {
 				const contribution = {
 					count: data[0] === 'No' ? 0 : +data[0],
-					name: data[3].replace(',', ''),
-					month: data[4],
-					day: +data[5].replace(',', ''),
-					year: +data[6],
+					month: data[3],
+					day: +data[4].replace(',', ''),
 					level: +day.dataset.level!,
 				}
 				currentRow.push(contribution)

--- a/src/routes/[user]/[year]/+server.ts
+++ b/src/routes/[user]/[year]/+server.ts
@@ -42,7 +42,7 @@ function parseContributions(html: string) {
 				const contribution = {
 					count: data[0] === 'No' ? 0 : +data[0],
 					month: data[3],
-					day: +data[4].replace(',', ''),
+					day: data[4].replace('.', ''),
 					level: +day.dataset.level!,
 				}
 				currentRow.push(contribution)


### PR DESCRIPTION
The GitHub table being scraped for users doesn't include `year` or `name` anymore so the array indices need to be adjusted.

<details>
    <summary>Screenshot example of new GitHub table</summary>

![image](https://github.com/joysofcode/sveltekit-web-scraping/assets/14914028/f4d9b463-79cf-40c2-a8ac-d46e8cc357dd)
</details>