### PR TITLE
fix: github contributions table parsing

### DIFF
--- a/src/routes/[user]/[year]/+server.ts
+++ b/src/routes/[user]/[year]/+server.ts
@@ -2,6 +2,13 @@ import { json } from '@sveltejs/kit'
 import { parseHTML } from 'linkedom'
 import type { RouteParams } from './$types.js'
 
+type Contribution = {
+	count: number
+	month: string
+	day: number
+	level: number
+} | null
+
 export async function GET({ params, setHeaders }) {
 	setHeaders({
 		'Acces-Control-Allow-Origin': '*',
@@ -28,7 +35,7 @@ function parseContributions(html: string) {
 
 	const days = document.querySelectorAll<Element>('tool-tip')
 
-	const contributions: any[][] = [
+	const contributions: Contribution[][] = [
 		[], // Sundays
 		[], // Mondays
 		[], // Tuesdays

--- a/src/routes/[user]/[year]/+server.ts
+++ b/src/routes/[user]/[year]/+server.ts
@@ -3,56 +3,68 @@ import { parseHTML } from 'linkedom'
 import type { RouteParams } from './$types.js'
 
 export async function GET({ params, setHeaders }) {
-	setHeaders({
-		'Acces-Control-Allow-Origin': '*',
-		'Cache-Control': `public, s-maxage=${60 * 60 * 24 * 365}`,
-	})
+  setHeaders({
+    'Acces-Control-Allow-Origin': '*',
+    'Cache-Control': `public, s-maxage=${60 * 60 * 24 * 365}`,
+  })
 
-	const html = await getContributions(params)
-	return json(parseContributions(html))
+  const html = await getContributions(params)
+  return json(parseContributions(html))
 }
 
 async function getContributions({ user, year }: RouteParams) {
-	const api = `https://github.com/users/${user}/contributions?from=${year}-12-01&to=${year}-12-31`
-	const response = await fetch(api)
+  const api = `https://github.com/users/${user}/contributions?from=${year}-12-01&to=${year}-12-31`
+  const response = await fetch(api)
 
-	if (!response.ok) {
-		throw new Error(`Failed to fetch: ${response.status}`)
-	}
+  if (!response.ok) {
+    throw new Error(`Failed to fetch: ${response.status}`)
+  }
 
-	return await response.text()
+  return await response.text()
 }
 
 function parseContributions(html: string) {
-	const { document } = parseHTML(html)
+  const { document } = parseHTML(html)
 
-	const rows = document.querySelectorAll<HTMLTableRowElement>('tbody > tr')
+  const days = document.querySelectorAll<Element>('tool-tip')
 
-	const contributions = []
+  const contributions: any[][] = [
+    [], // Sundays
+    [], // Mondays
+    [], // Tuesdays
+    [], // Wednesdays
+    [], // Thursdays
+    [], // Fridays
+    [], // Saturdays
+  ]
 
-	for (const row of rows) {
-		const days = row.querySelectorAll<HTMLTableCellElement>('td:not(.ContributionCalendar-label)')
+  for (const [i, day] of days.entries()) {
+    const data = day.innerHTML.split(' ')
 
-		const currentRow = []
+    const forDayRaw = day.getAttribute('for')
 
-		for (const day of days) {
-			const data = day.innerText.split(' ')
+    if (!forDayRaw) {
+      continue
+    }
+    const forDay = forDayRaw.replace('contribution-day-component-', '')
+    const [weekDayStr, weekStr] = forDay.split('-')
+    const weekday = +weekDayStr
+    const week = +weekStr
 
-			if (data.length > 1) {
-				const contribution = {
-					count: data[0] === 'No' ? 0 : +data[0],
-					month: data[3],
-					day: data[4].replace('.', ''),
-					level: +day.dataset.level!,
-				}
-				currentRow.push(contribution)
-			} else {
-				currentRow.push(null)
-			}
-		}
-
-		contributions.push(currentRow)
-	}
-
-	return contributions
+    if (data.length > 1) {
+      const td = document.getElementById(forDayRaw)
+      if (!td) {
+        continue
+      }
+      const level = td.dataset.level || '0'
+      const contribution = {
+        count: data[0] === 'No' ? 0 : +data[0],
+        month: data[3],
+        day: +data[4].replace(/(st|nd|rd|th)/, ''),
+        level: +level,
+      }
+      contributions[weekday][week] = contribution
+    }
+  }
+  return contributions
 }

--- a/src/routes/[user]/[year]/+server.ts
+++ b/src/routes/[user]/[year]/+server.ts
@@ -3,68 +3,64 @@ import { parseHTML } from 'linkedom'
 import type { RouteParams } from './$types.js'
 
 export async function GET({ params, setHeaders }) {
-  setHeaders({
-    'Acces-Control-Allow-Origin': '*',
-    'Cache-Control': `public, s-maxage=${60 * 60 * 24 * 365}`,
-  })
+	setHeaders({
+		'Acces-Control-Allow-Origin': '*',
+		'Cache-Control': `public, s-maxage=${60 * 60 * 24 * 365}`,
+	})
 
-  const html = await getContributions(params)
-  return json(parseContributions(html))
+	const html = await getContributions(params)
+	return json(parseContributions(html))
 }
 
 async function getContributions({ user, year }: RouteParams) {
-  const api = `https://github.com/users/${user}/contributions?from=${year}-12-01&to=${year}-12-31`
-  const response = await fetch(api)
+	const api = `https://github.com/users/${user}/contributions?from=${year}-12-01&to=${year}-12-31`
+	const response = await fetch(api)
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch: ${response.status}`)
-  }
+	if (!response.ok) {
+		throw new Error(`Failed to fetch: ${response.status}`)
+	}
 
-  return await response.text()
+	return await response.text()
 }
 
 function parseContributions(html: string) {
-  const { document } = parseHTML(html)
+	const { document } = parseHTML(html)
 
-  const days = document.querySelectorAll<Element>('tool-tip')
+	const days = document.querySelectorAll<Element>('tool-tip')
 
-  const contributions: any[][] = [
-    [], // Sundays
-    [], // Mondays
-    [], // Tuesdays
-    [], // Wednesdays
-    [], // Thursdays
-    [], // Fridays
-    [], // Saturdays
-  ]
+	const contributions: any[][] = [
+		[], // Sundays
+		[], // Mondays
+		[], // Tuesdays
+		[], // Wednesdays
+		[], // Thursdays
+		[], // Fridays
+		[], // Saturdays
+	]
 
-  for (const [i, day] of days.entries()) {
-    const data = day.innerHTML.split(' ')
+	for (const [_, day] of days.entries()) {
+		const data = day.innerHTML.split(' ')
 
-    const forDayRaw = day.getAttribute('for')
+		const forDayRaw = day.getAttribute('for')
+		if (!forDayRaw) continue
 
-    if (!forDayRaw) {
-      continue
-    }
-    const forDay = forDayRaw.replace('contribution-day-component-', '')
-    const [weekDayStr, weekStr] = forDay.split('-')
-    const weekday = +weekDayStr
-    const week = +weekStr
+		const forDay = forDayRaw.replace('contribution-day-component-', '')
+		const [weekday, week] = forDay.split('-').map(Number)
 
-    if (data.length > 1) {
-      const td = document.getElementById(forDayRaw)
-      if (!td) {
-        continue
-      }
-      const level = td.dataset.level || '0'
-      const contribution = {
-        count: data[0] === 'No' ? 0 : +data[0],
-        month: data[3],
-        day: +data[4].replace(/(st|nd|rd|th)/, ''),
-        level: +level,
-      }
-      contributions[weekday][week] = contribution
-    }
-  }
-  return contributions
+		if (data.length > 1) {
+			const td = document.getElementById(forDayRaw)
+			if (!td) continue
+
+			const level = td.dataset.level || '0'
+			const contribution = {
+				count: data[0] === 'No' ? 0 : +data[0],
+				month: data[3],
+				day: +data[4].replace(/(st|nd|rd|th)/, ''),
+				level: +level,
+			}
+			contributions[weekday][week] = contribution
+		}
+	}
+
+	return contributions
 }


### PR DESCRIPTION
GitHub has changed the contributions table again.

The `<td>` no longer has the contribution content via `innerText`, instead there's a `<tool-tip>` element alongside each `<td>` that contains the contribution content.

<details>
    <summary>Example td / tool-tip elements</summary>

```html
<td
  tabindex="0"
  data-ix="32"
  aria-selected="false"
  aria-describedby="contribution-graph-legend-level-0"
  style="width: 10px"
  data-date="2023-08-17"
  id="contribution-day-component-4-32"
  data-level="0"
  role="gridcell"
  data-view-component="true"
  class="ContributionCalendar-day"
></td>
<tool-tip
  id="tooltip-121ff1e4-1b70-40fb-9332-8209b3058f42"
  for="contribution-day-component-4-32"
  popover="manual"
  data-direction="n"
  data-type="label"
  data-view-component="true"
  class="sr-only position-absolute"
  >No contributions on August 17th.</tool-tip
>
```
</details>

This PR updates the DOM parsing to use both the `<td>` and the new `<tool-tip>` element to populate the contribution data.